### PR TITLE
Raise minimum Python support to 3.11 and narrow CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.11', '3.12']
     
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Red Set ProtoCell (RSP)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![CI](https://github.com/Arnoldlarry15/red-set-protocell/actions/workflows/ci.yml/badge.svg)](https://github.com/Arnoldlarry15/red-set-protocell/actions/workflows/ci.yml)
 [![Code Quality](https://github.com/Arnoldlarry15/red-set-protocell/actions/workflows/code-quality.yml/badge.svg)](https://github.com/Arnoldlarry15/red-set-protocell/actions/workflows/code-quality.yml)
 [![Security](https://github.com/Arnoldlarry15/red-set-protocell/actions/workflows/security.yml/badge.svg)](https://github.com/Arnoldlarry15/red-set-protocell/actions/workflows/security.yml)
@@ -426,7 +426,7 @@ Round N:
 
 ### Prerequisites
 
-- **Python 3.8+**
+- **Python 3.11+**
 - **API Key** from OpenAI or Anthropic
   - OpenAI: https://platform.openai.com/api-keys
   - Anthropic: https://console.anthropic.com/
@@ -705,7 +705,7 @@ docker-compose run rsp-backend python -m app.main --backend openai --api-key $OP
 ### System Requirements
 
 - **OS**: Linux, macOS, Windows (with WSL recommended)
-- **Python**: 3.8 or higher
+- **Python**: 3.11 or higher
 - **RAM**: 2GB minimum, 4GB recommended
 - **Disk**: 500MB for code, variable for session data
 - **Network**: Internet connection for API calls
@@ -1271,7 +1271,7 @@ mypy app/
 
 # Common mypy configuration (mypy.ini):
 [mypy]
-python_version = 3.8
+python_version = 3.11
 warn_return_any = True
 warn_unused_configs = True
 disallow_untyped_defs = True
@@ -2036,7 +2036,7 @@ A: Yes. RSP uses hashed fingerprinting for logging, and zero-retention mode (ena
 ### Technical Questions
 
 **Q: What Python version is required?**
-A: Python 3.8 or higher. Python 3.10+ is recommended.
+A: Python 3.11 or higher.
 
 **Q: Can I add support for other LLMs?**
 A: Yes! Implement the `TargetBackend` abstract class in `app/agents/target.py`. See [Development](#development) section for details.

--- a/backend/mypy.ini
+++ b/backend/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.9
+python_version = 3.11
 warn_return_any = False
 warn_unused_configs = True
 disallow_untyped_defs = False

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 127
-target-version = ['py38', 'py39', 'py310', 'py311', 'py312']
+target-version = ['py311', 'py312']
 include = '\.pyi?$'
 extend-exclude = '''
 /(
@@ -89,7 +89,7 @@ name = "red-set-protocell"
 version = "1.0.0"
 description = "An Open-source AI safety platform using dual-agent Sniper/Spotter red-teaming to audit and secure large language models"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 license = {text = "MIT"}
 authors = [
     {name = "Arnold Larry", email = "arnoldlarry15@users.noreply.github.com"}
@@ -101,9 +101,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",


### PR DESCRIPTION
### Motivation
- Prevent CI failures caused by modern typing/syntax being tested on old interpreters by raising the supported Python floor. 
- Keep developer tooling and documentation consistent with the supported interpreter to avoid confusion and false negatives in checks. 

### Description
- Narrowed the GitHub Actions CI matrix in `.github/workflows/ci.yml` to test only `python-version: ['3.11', '3.12']`.
- Raised the package metadata minimum in `backend/pyproject.toml` to `requires-python = ">=3.11"` and removed older Python classifiers, and adjusted Black `target-version` to `['py311','py312']`.
- Aligned type-checking configuration by setting `python_version = 3.11` in `backend/mypy.ini`.
- Updated `README.md` to the `Python 3.11+` badge and all references to prerequisites, system requirements, and the MyPy example to consistently state `3.11` as the minimum.

### Testing
- Ran `cd backend && python -m pytest tests/test_config.py -q`, which completed successfully (`13 passed`) and produced coverage artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996d575aa64832eb8837631cf86f758)