### PR TITLE
Fix unresolved merge conflict markers in frontend auth files

### DIFF
--- a/frontend/src/pages/AuthPage.tsx
+++ b/frontend/src/pages/AuthPage.tsx
@@ -5,13 +5,7 @@ import axios from 'axios';
 import { User } from '../types';
 import '../styles/Auth.css';
 import { getUserFriendlyApiError } from '../utils/apiErrors';
-<<<<<<< copilot/sub-pr-155-again
-
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
-=======
 import { API_BASE_URL } from '../utils/config';
-
->>>>>>> main
 
 interface AuthPageProps {
   onAuth: (apiKey: string, backend: string, userData?: User) => void;

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -5,13 +5,7 @@ import axios from 'axios';
 import { User } from '../types';
 import '../styles/Auth.css';
 import { getUserFriendlyApiError } from '../utils/apiErrors';
-<<<<<<< copilot/sub-pr-155-again
-
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
-=======
 import { API_BASE_URL } from '../utils/config';
-
->>>>>>> main
 
 interface LoginPageProps {
   onAuth: (apiKey: string, backend: string, userData?: User) => void;

--- a/frontend/src/utils/apiErrors.ts
+++ b/frontend/src/utils/apiErrors.ts
@@ -1,24 +1,4 @@
 import axios from 'axios';
-<<<<<<< copilot/sub-pr-155-again
-
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
-
-/**
- * Converts an unknown thrown value into a human-readable error string.
- * Uses axios.isAxiosError for safe, type-narrowed access to response details.
- */
-export const getUserFriendlyApiError = (error: unknown): string => {
-  if (axios.isAxiosError(error)) {
-    if (error.response?.data?.detail) return String(error.response.data.detail);
-
-    if (error.message === 'Network Error' || error.code === 'ERR_NETWORK') {
-      return `Cannot reach backend at ${API_BASE_URL}. Check VITE_API_BASE_URL, backend availability, and CORS origin settings.`;
-    }
-
-    return error.message || 'An unexpected error occurred';
-  }
-
-=======
 import { API_BASE_URL } from './config';
 
 export const getUserFriendlyApiError = (error: unknown, fallback = 'An unexpected error occurred'): string => {
@@ -29,6 +9,5 @@ export const getUserFriendlyApiError = (error: unknown, fallback = 'An unexpecte
     }
     return error.message || fallback;
   }
->>>>>>> main
   return String(error);
 };


### PR DESCRIPTION
### Motivation
- Unresolved merge conflict markers remained in frontend auth-related files and caused ESLint/TypeScript parsing failures, blocking lint and build pipelines.

### Description
- Removed leftover Git merge markers and restored the single shared `API_BASE_URL` import from `./utils/config` in `frontend/src/pages/AuthPage.tsx` and `frontend/src/pages/LoginPage.tsx`.
- Consolidated `getUserFriendlyApiError` into a single coherent implementation in `frontend/src/utils/apiErrors.ts` that imports `API_BASE_URL` from `./config` and preserves previous behavior.
- Total files modified: 3 (`frontend/src/pages/AuthPage.tsx`, `frontend/src/pages/LoginPage.tsx`, `frontend/src/utils/apiErrors.ts`); no API, dependency, CI, or architecture changes were introduced.

### Testing
- Ran `cd frontend && npm run lint` — succeeded (no ESLint parsing errors).
- Ran `cd frontend && npm run build` — succeeded (production build completed).
- Attempted `cd backend && make lint` and `cd backend && make test` but these could not be completed in this environment due to missing Python tooling and network/proxy restrictions, and no backend files were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999807bb604832e8c80b5efa5b88d9b)