### PR TITLE
Split scope: keep PostgreSQL storage seam isolated from auth/frontend changes

### DIFF
--- a/backend/app/agents/orchestrator.py
+++ b/backend/app/agents/orchestrator.py
@@ -126,6 +126,7 @@ from app.core.manifest import AttackManifest, create_manifest_from_config
 from app.core.security import generate_session_id
 from app.core.specimen import FailureSpecimen, create_specimen_from_evaluation
 from app.engines.scoring import ScoringEngine
+from app.storage import create_storage_adapter
 
 logger = logging.getLogger(__name__)
 
@@ -163,6 +164,8 @@ class StateManager:
         database_path: str = "rsp_session.db",
         zero_retention: bool = True,
         model_version: str = "unknown",
+        storage_mode: Optional[str] = None,
+        postgres_dsn: Optional[str] = None,
     ):
         """
         Initialize state manager.
@@ -177,6 +180,17 @@ class StateManager:
         self.session_id = generate_session_id()
         self.model_version = model_version
         self.session_start_time = datetime.now(timezone.utc).isoformat()
+        self.storage_mode = (storage_mode or os.getenv("RSP_STORAGE_MODE", "sqlite")).strip().lower()
+
+        postgres_uri = postgres_dsn or os.getenv("RSP_POSTGRES_URI", "")
+        self.storage_adapter = create_storage_adapter(self.storage_mode, self.database_path, postgres_uri)
+        self.storage_adapter.health_check_sync()
+
+        if self.storage_mode == "postgres":
+            raise RuntimeError(
+                "Postgres adapter scaffold initialized successfully, but StateManager SQL operations are still "
+                "SQLite-specific in this phase. Set RSP_STORAGE_MODE=sqlite until cutover phase wiring is complete."
+            )
 
         # Initialize database
         self._init_database()
@@ -187,7 +201,8 @@ class StateManager:
         cursor = conn.cursor()
 
         # Create rounds table with model_version and session_start_time
-        cursor.execute("""
+        cursor.execute(
+            """
             CREATE TABLE IF NOT EXISTS rounds (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 session_id TEXT NOT NULL,
@@ -202,17 +217,20 @@ class StateManager:
                 model_version TEXT DEFAULT 'unknown',
                 session_start_time TEXT
             )
-        """)
+        """
+        )
 
         # Create metadata table
-        cursor.execute("""
+        cursor.execute(
+            """
             CREATE TABLE IF NOT EXISTS metadata (
                 session_id TEXT PRIMARY KEY,
                 created_at TEXT NOT NULL,
                 config TEXT NOT NULL,
                 model_version TEXT DEFAULT 'unknown'
             )
-        """)
+        """
+        )
 
         # Add model_version column if it doesn't exist (migration)
         try:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -307,7 +307,8 @@ def parse_arguments():
 
 if __name__ == "__main__":
     # Display banner
-    print("""
+    print(
+        """
     ╔═══════════════════════════════════════════════════════════╗
     ║                                                           ║
     ║         RED SET PROTOCELL (RSP)                           ║
@@ -316,7 +317,8 @@ if __name__ == "__main__":
     ║         Defense-Only | Zero-Retention | Ethical           ║
     ║                                                           ║
     ╚═══════════════════════════════════════════════════════════╝
-    """)
+    """
+    )
 
     # Parse arguments
     args = parse_arguments()

--- a/backend/app/storage/__init__.py
+++ b/backend/app/storage/__init__.py
@@ -1,0 +1,14 @@
+"""Storage adapter factory."""
+
+from __future__ import annotations
+
+from app.storage.base import StorageAdapter
+from app.storage.postgres_adapter import PostgresStorageAdapter
+from app.storage.sqlite_adapter import SQLiteStorageAdapter
+
+
+def create_storage_adapter(mode: str, database_path: str, postgres_dsn: str | None = None) -> StorageAdapter:
+    normalized = (mode or "sqlite").strip().lower()
+    if normalized == "postgres":
+        return PostgresStorageAdapter(postgres_dsn or "")
+    return SQLiteStorageAdapter(database_path)

--- a/backend/app/storage/base.py
+++ b/backend/app/storage/base.py
@@ -1,0 +1,27 @@
+"""Storage adapter interfaces for StateManager persistence backends."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from contextlib import AbstractAsyncContextManager, AbstractContextManager
+
+
+class StorageAdapter(ABC):
+    """Narrow storage contract for persistence backends."""
+
+    @property
+    @abstractmethod
+    def backend_name(self) -> str:
+        """Human-readable backend identifier."""
+
+    @abstractmethod
+    def health_check_sync(self) -> None:
+        """Validate connectivity/operability for sync code paths."""
+
+    @abstractmethod
+    def transaction_sync(self) -> AbstractContextManager:
+        """Provide a sync transaction context manager."""
+
+    @abstractmethod
+    def transaction_async(self) -> AbstractAsyncContextManager:
+        """Provide an async transaction context manager."""

--- a/backend/app/storage/postgres_adapter.py
+++ b/backend/app/storage/postgres_adapter.py
@@ -1,0 +1,49 @@
+"""PostgreSQL storage adapter scaffold for incremental integration."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import AbstractAsyncContextManager, AbstractContextManager
+from typing import Optional
+
+from app.storage.base import StorageAdapter
+
+
+class PostgresStorageAdapter(StorageAdapter):
+    """Asyncpg-backed adapter scaffold (Phase 1)."""
+
+    def __init__(self, postgres_dsn: str):
+        if not postgres_dsn:
+            raise ValueError("PostgreSQL DSN is required for postgres adapter")
+        self.postgres_dsn = postgres_dsn
+        self._pool = None
+
+    @property
+    def backend_name(self) -> str:
+        return "postgres"
+
+    async def _ensure_pool(self):
+        if self._pool is not None:
+            return self._pool
+
+        try:
+            import asyncpg
+        except ImportError as exc:  # pragma: no cover - environment dependent
+            raise RuntimeError("asyncpg is required for Postgres mode. Install dependencies including asyncpg.") from exc
+
+        self._pool = await asyncpg.create_pool(self.postgres_dsn, min_size=1, max_size=5)
+        return self._pool
+
+    async def _health_check_async(self) -> None:
+        pool = await self._ensure_pool()
+        async with pool.acquire() as conn:
+            await conn.execute("SELECT 1")
+
+    def health_check_sync(self) -> None:
+        asyncio.run(self._health_check_async())
+
+    def transaction_sync(self) -> AbstractContextManager:
+        raise NotImplementedError("Sync transaction path is not implemented for Postgres scaffold")
+
+    def transaction_async(self) -> AbstractAsyncContextManager:
+        raise NotImplementedError("Async transaction path will be enabled during Postgres cutover phase")

--- a/backend/app/storage/sqlite_adapter.py
+++ b/backend/app/storage/sqlite_adapter.py
@@ -1,0 +1,53 @@
+"""SQLite storage adapter implementation."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import asynccontextmanager, contextmanager
+from typing import AsyncIterator, Iterator
+
+import aiosqlite
+
+from app.storage.base import StorageAdapter
+
+
+class SQLiteStorageAdapter(StorageAdapter):
+    """SQLite adapter used by current StateManager implementation."""
+
+    def __init__(self, database_path: str):
+        self.database_path = database_path
+
+    @property
+    def backend_name(self) -> str:
+        return "sqlite"
+
+    def health_check_sync(self) -> None:
+        conn = sqlite3.connect(self.database_path)
+        try:
+            conn.execute("SELECT 1")
+        finally:
+            conn.close()
+
+    @contextmanager
+    def transaction_sync(self) -> Iterator[sqlite3.Connection]:
+        conn = sqlite3.connect(self.database_path)
+        try:
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    @asynccontextmanager
+    async def transaction_async(self) -> AsyncIterator[aiosqlite.Connection]:
+        conn = await aiosqlite.connect(self.database_path)
+        try:
+            yield conn
+            await conn.commit()
+        except Exception:
+            await conn.rollback()
+            raise
+        finally:
+            await conn.close()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,7 @@ numpy>=1.20.0,<2.0.0
 
 # Async support
 aiosqlite>=0.19.0
+asyncpg>=0.29.0
 
 # API clients - REQUIRED (no mock backends)
 openai>=1.0.0

--- a/backend/tests/test_storage_adapters.py
+++ b/backend/tests/test_storage_adapters.py
@@ -135,6 +135,29 @@ def test_postgres_adapter_import_error_message(monkeypatch):
         asyncio.run(adapter._ensure_pool())
 
 
+def test_postgres_health_check_sync_uses_asyncio_run(monkeypatch):
+    adapter = PostgresStorageAdapter("postgresql://user:pass@localhost:5432/rsp")
+    called = {"count": 0}
+
+    def _fake_run(_coroutine):
+        called["count"] += 1
+        _coroutine.close()
+        return None
+
+    monkeypatch.setattr("app.storage.postgres_adapter.asyncio.run", _fake_run)
+
+    adapter.health_check_sync()
+    assert called["count"] == 1
+
+
+def test_state_manager_defaults_to_sqlite_mode(tmp_path):
+    db_path = str(tmp_path / "state_default.db")
+    manager = StateManager(database_path=db_path)
+
+    assert manager.storage_mode == "sqlite"
+    assert manager.storage_adapter.backend_name == "sqlite"
+
+
 def test_state_manager_rejects_postgres_mode_until_cutover(monkeypatch, tmp_path):
     db_path = str(tmp_path / "test.db")
 

--- a/backend/tests/test_storage_adapters.py
+++ b/backend/tests/test_storage_adapters.py
@@ -1,4 +1,8 @@
 import pytest
+import sqlite3
+import sys
+import types
+import asyncio
 
 from app.agents.orchestrator import StateManager
 from app.storage import create_storage_adapter
@@ -19,12 +23,116 @@ def test_create_storage_adapter_postgres_requires_dsn(tmp_path):
         create_storage_adapter("postgres", db_path)
 
 
+def test_create_storage_adapter_postgres_returns_postgres_adapter(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    adapter = create_storage_adapter("postgres", db_path, "postgresql://user:pass@localhost:5432/rsp")
+    assert isinstance(adapter, PostgresStorageAdapter)
+    assert adapter.backend_name == "postgres"
+
+
 def test_postgres_adapter_transaction_methods_not_implemented():
     adapter = PostgresStorageAdapter("postgresql://user:pass@localhost:5432/rsp")
     with pytest.raises(NotImplementedError):
         adapter.transaction_sync()
     with pytest.raises(NotImplementedError):
         adapter.transaction_async()
+
+
+def test_sqlite_adapter_sync_transaction_commit_and_rollback(tmp_path):
+    db_path = str(tmp_path / "sqlite_sync.db")
+    adapter = SQLiteStorageAdapter(db_path)
+
+    with adapter.transaction_sync() as conn:
+        conn.execute("CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)")
+        conn.execute("INSERT INTO events (name) VALUES (?)", ("ok",))
+
+    with sqlite3.connect(db_path) as verify_conn:
+        count = verify_conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+    assert count == 1
+
+    with pytest.raises(RuntimeError):
+        with adapter.transaction_sync() as conn:
+            conn.execute("INSERT INTO events (name) VALUES (?)", ("rollback",))
+            raise RuntimeError("force rollback")
+
+    with sqlite3.connect(db_path) as verify_conn:
+        count_after = verify_conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+    assert count_after == 1
+
+
+def test_sqlite_adapter_async_transaction_commit_and_rollback(tmp_path):
+    db_path = str(tmp_path / "sqlite_async.db")
+    adapter = SQLiteStorageAdapter(db_path)
+
+    async def _run():
+        async with adapter.transaction_async() as conn:
+            await conn.execute("CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)")
+            await conn.execute("INSERT INTO events (name) VALUES (?)", ("ok",))
+
+        with sqlite3.connect(db_path) as verify_conn:
+            count = verify_conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+        assert count == 1
+
+        with pytest.raises(RuntimeError):
+            async with adapter.transaction_async() as conn:
+                await conn.execute("INSERT INTO events (name) VALUES (?)", ("rollback",))
+                raise RuntimeError("force rollback")
+
+        with sqlite3.connect(db_path) as verify_conn:
+            count_after = verify_conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+        assert count_after == 1
+
+    asyncio.run(_run())
+
+
+def test_postgres_adapter_ensure_pool_uses_asyncpg_and_caches(monkeypatch):
+    adapter = PostgresStorageAdapter("postgresql://user:pass@localhost:5432/rsp")
+    created = {"count": 0}
+
+    class _DummyConn:
+        async def execute(self, _sql):
+            return None
+
+    class _AcquireCtx:
+        async def __aenter__(self):
+            return _DummyConn()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _DummyPool:
+        def acquire(self):
+            return _AcquireCtx()
+
+    async def _create_pool(_dsn, min_size=1, max_size=5):
+        assert min_size == 1
+        assert max_size == 5
+        created["count"] += 1
+        return _DummyPool()
+
+    fake_asyncpg = types.SimpleNamespace(create_pool=_create_pool)
+    monkeypatch.setitem(sys.modules, "asyncpg", fake_asyncpg)
+
+    asyncio.run(adapter._health_check_async())
+    asyncio.run(adapter._health_check_async())
+    assert created["count"] == 1
+
+
+def test_postgres_adapter_import_error_message(monkeypatch):
+    adapter = PostgresStorageAdapter("postgresql://user:pass@localhost:5432/rsp")
+    monkeypatch.delitem(sys.modules, "asyncpg", raising=False)
+
+    original_import = __import__
+
+    def _failing_import(name, *args, **kwargs):
+        if name == "asyncpg":
+            raise ImportError("missing")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", _failing_import)
+
+    with pytest.raises(RuntimeError, match="asyncpg is required for Postgres mode"):
+        asyncio.run(adapter._ensure_pool())
 
 
 def test_state_manager_rejects_postgres_mode_until_cutover(monkeypatch, tmp_path):

--- a/backend/tests/test_storage_adapters.py
+++ b/backend/tests/test_storage_adapters.py
@@ -1,0 +1,48 @@
+import pytest
+
+from app.agents.orchestrator import StateManager
+from app.storage import create_storage_adapter
+from app.storage.postgres_adapter import PostgresStorageAdapter
+from app.storage.sqlite_adapter import SQLiteStorageAdapter
+
+
+def test_create_storage_adapter_defaults_to_sqlite(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    adapter = create_storage_adapter("", db_path)
+    assert isinstance(adapter, SQLiteStorageAdapter)
+    adapter.health_check_sync()
+
+
+def test_create_storage_adapter_postgres_requires_dsn(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    with pytest.raises(ValueError, match="PostgreSQL DSN is required"):
+        create_storage_adapter("postgres", db_path)
+
+
+def test_postgres_adapter_transaction_methods_not_implemented():
+    adapter = PostgresStorageAdapter("postgresql://user:pass@localhost:5432/rsp")
+    with pytest.raises(NotImplementedError):
+        adapter.transaction_sync()
+    with pytest.raises(NotImplementedError):
+        adapter.transaction_async()
+
+
+def test_state_manager_rejects_postgres_mode_until_cutover(monkeypatch, tmp_path):
+    db_path = str(tmp_path / "test.db")
+
+    class DummyAdapter:
+        backend_name = "postgres"
+
+        def health_check_sync(self):
+            return None
+
+        def transaction_sync(self):
+            raise NotImplementedError
+
+        def transaction_async(self):
+            raise NotImplementedError
+
+    monkeypatch.setattr("app.agents.orchestrator.create_storage_adapter", lambda *args, **kwargs: DummyAdapter())
+
+    with pytest.raises(RuntimeError, match="SQLite-specific"):
+        StateManager(database_path=db_path, storage_mode="postgres")

--- a/backend/tests/test_time_tracking.py
+++ b/backend/tests/test_time_tracking.py
@@ -32,7 +32,8 @@ def temp_database():
     conn = sqlite3.connect(db_path)
     cursor = conn.cursor()
 
-    cursor.execute("""
+    cursor.execute(
+        """
         CREATE TABLE rounds (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             session_id TEXT NOT NULL,
@@ -47,7 +48,8 @@ def temp_database():
             model_version TEXT DEFAULT 'unknown',
             session_start_time TEXT
         )
-    """)
+    """
+    )
 
     conn.commit()
     conn.close()


### PR DESCRIPTION
## Summary
- Reverted non-storage changes from this branch to keep the PostgreSQL phase-1 seam PR surgically scoped.
- Restored prior auth/frontend and API key-validation files to pre-storage-seam behavior:
  - `backend/app/api_server.py`
  - `backend/tests/test_api_endpoints.py`
  - `frontend/src/pages/AuthPage.tsx`
  - `frontend/src/pages/Dashboard.tsx`
  - `frontend/src/pages/LoginPage.tsx`
  - `frontend/src/types/index.ts`

## Why
The previous squashed commit bundled unrelated auth/frontend deltas with storage-seam work. This follow-up commit isolates scope so the storage adapter PR can be audited cleanly as infrastructure-only.

## Validation
- `cd frontend && npm run lint` ✅
- `cd backend && python -m black --check app/agents/orchestrator.py app/storage/*.py tests/test_storage_adapters.py` ✅
- `cd backend && pytest -q tests/test_storage_adapters.py -o addopts=''` ✅
- `cd backend && pytest -q tests/test_api_endpoints.py -o addopts=''` ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a5825a0c0832eb13eddf8d7de2f6a)